### PR TITLE
fix(#57): prettier-plugin-tailwindcss 적용 안되는 문제 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -12,7 +12,7 @@
     "^[./]"
   ],
   "plugins": [
-    "prettier-plugin-tailwindcss",
-    "@ianvs/prettier-plugin-sort-imports"
+    "@ianvs/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
   ]
 }


### PR DESCRIPTION
## 연관된 이슈

> close #57

## 작업 내용

- prettier-plugin-tailwindcss이 적용 안되는 문제를 해결했습니다.
- `.prettierrc`의 plugin 순서를 바꿔서 해결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 코드 포매팅 플러그인 구성 순서를 최적화하여 포매팅 프로세스 동작을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->