### PR TITLE
chore(#66): pre-push 과정에서 변경된 파일에 대해서만 테스트 진행

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,6 +6,12 @@ pnpm exec tsc --noEmit || {
     exit 1
 }
 
+echo "📡 원격 브랜치 정보 업데이트 중..."
+git fetch origin main || {
+    echo "⚠️  원격 브랜치를 가져올 수 없습니다."
+    exit 1
+}
+
 echo "🧪 변경된 파일 기준 테스트 실행 중..."
 pnpm jest --changedSince=origin/main || {
     echo "⚠️  테스트에 실패했습니다. push가 중단됩니다."


### PR DESCRIPTION
## 연관된 이슈

- close #66 

## 작업 내용

pre-push 시에 모든 테스트를 확인하느라 시간이 오래 걸리는데, 변경 사항에 대한 test만 진행 가능한지 확인해봤는데,
jest에 [--changedSince](https://jestjs.io/docs/cli#--changedsince)라는 옵션이 존재한다고 합니다!
이 옵션을 활용하면 설정된 브랜치 기준으로 변경된 파일들에 대해서만 테스트가 가능하다고 합니다!
```bash
pnpm jest --changedSince=origin/main
```
지금 테스트 파일이 제꺼밖에 없어서 `feature/components/pace-slider`에 push한다고 가정하고 그거 기준으로 테스트해봤습니다! (main에 테스트가 없어서 단지 시연을 위한 예시입니다! 저희 작업 시에는 main이랑 비교합니다!)

## 테스트과정

### **`test-branch(feature/components/pace-slider를 Base branch로 생성한 브랜치)` -> `feature/components/pace-slider(PaceSlider 존재)`** 
   1) **`test-branch`** 에서 **PaceSlider 컴포넌트 수정** 후 push하는 경우 **=> 변경된 파일 : `PaceSlider.tsx`**
   PaceSlider 파일에 대한 **테스트 자동으로 수행**
  <img width="1718" height="363" alt="Image" src="https://github.com/user-attachments/assets/1c2ab374-197f-446a-aa3f-8d74c44db955" />

   2) **`test-branch`** 에서 util 함수 등 **테스트 파일과 관련 없는 파일 작성/수정** 후 push하는 경우 **=> 변경된 파일 : `utils.ts`**
  변경사항에 대한 테스트 파일이 없으므로 **테스트 진행 x**
  
<img width="1712" height="123" alt="Image" src="https://github.com/user-attachments/assets/7b35fcfe-e458-4134-a63f-a4163767fc7d" />

## 기타

참고
- [jest 공식문서](https://jestjs.io/docs/cli#--changedsince)
- [stackoverflow 관련 글](https://stackoverflow.com/questions/63663011/run-tests-with-husky-pre-push-only-when-there-are-changes?utm_source=chatgpt.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 푸시 전 훅을 개선하여 변경된 파일에 대해서만 테스트를 실행하도록 업데이트했습니다.
  * 테스트 실행 실패 시 푸시가 중단되고 타입 검사와 성공 메시지 출력 흐름은 유지됩니다.

* **영향**
  * 개발자 워크플로우 개선 — 최종 사용자에게는 직접적인 영향 없음.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->