### PR TITLE
 chore(#91): twMerge 오류 해결을 위해 extendTailwindMerge 사용하여 cn함수 수정

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,38 @@
 import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
 
+// 커스텀 twMerge 함수 생성
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      // 폰트 사이즈 관련 커스텀 클래스들을 별도 그룹으로 분리
+      'font-size': [
+        'text-title3-semibold',
+        'text-title3-bold',
+        'text-title2-semibold',
+        'text-title2-bold',
+        'text-title1-semibold',
+        'text-title1-bold',
+        'text-body1-semibold',
+        'text-body1-bold',
+        'text-body2-regular',
+        'text-body2-medium',
+        'text-body2-semibold',
+        'text-body2-bold',
+        'text-body3-regular',
+        'text-body3-medium',
+        'text-body3-semibold',
+        'text-body3-bold',
+        'text-caption-regular',
+        'text-caption-medium',
+        'text-caption-semibold',
+        'text-caption-bold',
+      ],
+    },
+  },
+});
+
+// twMerge > customTwMerge 함수 수정
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 }


### PR DESCRIPTION
## 연관된 이슈

- close #91 

## 작업 내용

- twMerge로 인해 발생하는 오류를 해결하기 위해 tailwind-merge의 extendTailwindMerge를 사용
- utility 함수들을 font-size 그룹으로 분리

### 스크린샷 (선택)

이제 잘 동작합니다!
```tsx
<p className="text-brand-500 text-title1-bold">text 테스트</p>
<p className={cn('text-brand-500', 'text-title1-bold')}>text 테스트</p>
<p className={cn('text-title1-bold', 'text-brand-500')}>text 테스트</p>
```

<img width="508" height="292" alt="image" src="https://github.com/user-attachments/assets/de1c9abd-48a8-433e-9ec3-0d05199ce06e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링 (Refactor)**
  * 스타일 통합 기능의 내부 구조를 개선했습니다. Tailwind 통합 방식을 확장하여 더욱 견고한 스타일 처리를 제공합니다. 공개 API는 변경되지 않아 기존 코드와의 호환성이 완벽하게 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->