### PR TITLE
feature(#106) : Rating 컴포넌트의 별 색상에 hover 색상 추가

### DIFF
--- a/src/components/ui/Rating/Rating.stories.tsx
+++ b/src/components/ui/Rating/Rating.stories.tsx
@@ -63,7 +63,7 @@ export const Default: Story = {
   args: {
     value: 3,
     max: 5,
-    size: 16,
+    size: 30,
     disabled: false,
   },
   render: function Render(args) {

--- a/src/components/ui/Rating/index.tsx
+++ b/src/components/ui/Rating/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Star from '@/assets/icons/star.svg';
+import Star from '@/assets/icons/star.svg?react';
 import { cn } from '@/lib/utils';
 
 interface RatingProps {


### PR DESCRIPTION
## 연관된 이슈

- close #106 

## 작업 내용

기존 구현해둔 방식은 현재 선택된 별점과 선택 할 별점의 색상이 같아서 헷갈리는 문제가 있었습니다.
그래서, 선택 예정인 별점의 색상을 다르게 했습니다.

### 스크린샷 (선택)

- **기존 방식**
![이전 rating 컴포넌트](https://github.com/user-attachments/assets/2fa470d1-82fa-4a94-8fb0-09946ac16b28)

- **변경된 방식**
![현재 rating 컴포넌트](https://github.com/user-attachments/assets/daea99b0-cd55-4901-87ba-fba4f0ca7786)

## 리뷰 요구사항(선택)

- 제 생각에는 이게 최선인 것 같은데 혹시 다른 좋은 방식이 있으면 말씀주세요!

- 디자이너 분이 설정해주신 hover 시 별 색상이 위 영상에 사용된 색상인데 뭔가 기존 빈 별 색상이랑 비슷해보여서 
한단계만 더 밝게 해도 괜찮다고 생각이 드는데 다른분들은 어떠신가요?

- 빈 별 색상 : gray-600
- hover 색상 : gray-400  **--> gray-300으로 변경 제안!**
- active 색상 : gray-100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Rating 컴포넌트에 대한 Storybook 스토리 추가로 사용 예시와 인터랙션 문서화 개선

* **개선사항**
  * 별 채우기(평점) 표시 및 호버 동작 로직 개선으로 시각적 일관성 향상 및 응답성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->