### PR TITLE
refactor: request body types 분리 (auth, crews, reviews, sessions, user API)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,11 +1,13 @@
-import { ResponseData, ResponseErrorData, User } from '@/types';
+import {
+  ResponseData,
+  ResponseErrorData,
+  User,
+  UserCredentials,
+} from '@/types';
 
-type UserCredentials = {
-  email: string;
-  password: string;
-};
+export type SignupRequestBody = UserCredentials & { name: string };
 
-export async function postSignup(body: UserCredentials & { name: string }) {
+export async function postSignup(body: SignupRequestBody) {
   const response = await fetch('/api/auth/signup', {
     method: 'POST',
     body: JSON.stringify(body),
@@ -25,7 +27,9 @@ export async function postSignup(body: UserCredentials & { name: string }) {
   return data;
 }
 
-export async function postSignin(body: UserCredentials) {
+export type SigninRequestBody = UserCredentials;
+
+export async function postSignin(body: SigninRequestBody) {
   const response = await fetch('/api/auth/signin', {
     method: 'POST',
     body: JSON.stringify(body),

--- a/src/api/crews.ts
+++ b/src/api/crews.ts
@@ -4,12 +4,17 @@ import {
   Profile,
   ResponseData,
   ResponseErrorData,
+  Role,
   SliceData,
+  User,
 } from '@/types';
 
-export async function createCrew(
-  body: Pick<Crew, 'name' | 'description' | 'city' | 'image'>
-) {
+export type CrewRequestBody = Pick<
+  Crew,
+  'name' | 'description' | 'city' | 'image'
+>;
+
+export async function createCrew(body: CrewRequestBody) {
   // const accessToken = '';
   const response = await fetch('/api/crews', {
     method: 'POST',
@@ -98,7 +103,7 @@ export async function getCrewMembers(
   return data;
 }
 
-export async function getCrewMemberCount(crewId: string) {
+export async function getCrewMembersCount(crewId: string) {
   const response = await fetch(`/api/crews/${crewId}/members/count`);
 
   if (!response.ok) {
@@ -110,12 +115,13 @@ export async function getCrewMemberCount(crewId: string) {
     }
   }
 
-  type CrewMemberCountResponseData = {
+  type CrewMembersCountResponseData = {
     leaderCount: number;
     staffCount: number;
     memberCount: number;
   };
-  const { data }: ResponseData<CrewMemberCountResponseData> =
+
+  const { data }: ResponseData<CrewMembersCountResponseData> =
     await response.json();
   return data;
 }
@@ -136,9 +142,13 @@ export async function getCrewMemberDetailById(crewId: string, userId: string) {
   return data;
 }
 
+type DelegateCrewLeaderRequestBody = {
+  newLeaderId: User['id'];
+};
+
 export async function delegateCrewLeader(
   crewId: string,
-  body: { newLeaderId: number }
+  body: DelegateCrewLeaderRequestBody
 ) {
   // const accessToken = '';
   const response = await fetch(`/api/crews/${crewId}/leader`, {
@@ -164,13 +174,17 @@ export async function delegateCrewLeader(
   return data;
 }
 
+export type UpdateMemberRoleRequestBody = {
+  role: Exclude<Role, 'LEADER'>;
+};
+
 export async function updateMemberRole(
   crewId: string,
   userId: string,
-  body: { role: 'STAFF' | 'MEMBER' }
+  body: UpdateMemberRoleRequestBody
 ) {
   // const accessToken = '';
-  const response = await fetch(`/api/crews/${crewId}/${userId}/role`, {
+  const response = await fetch(`/api/crews/${crewId}/members/${userId}/role`, {
     method: 'PATCH',
     body: JSON.stringify(body),
   });
@@ -220,9 +234,14 @@ export async function expelMember(crewId: string, userId: string) {
   return data;
 }
 
+export type UpdateCrewDetailRequestBody = Pick<
+  Crew,
+  'name' | 'description' | 'city' | 'image'
+>;
+
 export async function updateCrewDetail(
   crewId: string,
-  body: Pick<Crew, 'name' | 'description' | 'city' | 'image'>
+  body: UpdateCrewDetailRequestBody
 ) {
   // const accessToken = '';
   const response = await fetch(`/api/crews/${crewId}`, {

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -6,9 +6,14 @@ import {
   Review,
 } from '@/types';
 
+export type CreateSessionReviewResponseData = Pick<
+  Review,
+  'description' | 'ranks' | 'image'
+>;
+
 export async function createSessionReview(
   sessionId: string,
-  body: Pick<Review, 'description' | 'ranks' | 'image'>
+  body: CreateSessionReviewResponseData
 ) {
   // const accessToken = '';
   const response = await fetch(`/api/sessions/${sessionId}/reviews`, {

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -38,21 +38,21 @@ export async function getSessions(
   return data;
 }
 
-export async function createSession(
-  body: Pick<
-    Session,
-    | 'crewId'
-    | 'name'
-    | 'description'
-    | 'image'
-    | 'location'
-    | 'sessionAt'
-    | 'registerBy'
-    | 'level'
-    | 'maxParticipantCount'
-    | 'pace'
-  >
-) {
+export type CreateSessionRequestBody = Pick<
+  Session,
+  | 'crewId'
+  | 'name'
+  | 'description'
+  | 'image'
+  | 'location'
+  | 'sessionAt'
+  | 'registerBy'
+  | 'level'
+  | 'maxParticipantCount'
+  | 'pace'
+>;
+
+export async function createSession(body: CreateSessionRequestBody) {
   // const accessToken = '';
   const response = await fetch('/api/sessions', {
     method: 'POST',
@@ -186,10 +186,15 @@ export async function getSessionParticipants(sessionId: string) {
   return data;
 }
 
+export type UpdateSessionDetailRequestBody = Pick<
+  Session,
+  'name' | 'description' | 'image'
+>;
+
 // TODO: updateSessionDetail는 백엔드 문서화 후 수정 필요
 export async function updateSessionDetail(
   sessionId: string,
-  body: Pick<Session, 'name' | 'description' | 'image'>
+  body: UpdateSessionDetailRequestBody
 ) {
   // const accessToken = '';
   const response = await fetch(`/api/sessions/${sessionId}`, {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -17,14 +17,11 @@ export async function getCurrentUserProfile() {
   return data;
 }
 
-export async function updateUserProfile(
-  body: Partial<
-    Pick<
-      Profile,
-      'name' | 'image' | 'introduction' | 'city' | 'pace' | 'styles'
-    >
-  >
-) {
+export type UpdateUserProfileRequestBody = Partial<
+  Pick<Profile, 'name' | 'image' | 'introduction' | 'city' | 'pace' | 'styles'>
+>;
+
+export async function updateUserProfile(body: UpdateUserProfileRequestBody) {
   // const accessToken = '';
   const response = await fetch('/api/user', {
     method: 'PATCH',

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,6 +4,11 @@ export interface User {
   createdAt: string;
 }
 
+export type UserCredentials = {
+  email: string;
+  password: string;
+};
+
 export interface Profile extends User {
   image?: string;
   introduction: string;
@@ -13,7 +18,8 @@ export interface Profile extends User {
   updatedAt: string;
 }
 
-type Role = 'LEADER' | 'STAFF' | 'MEMBER';
+export type Role = 'LEADER' | 'STAFF' | 'MEMBER';
+
 export interface Member extends User {
   role: Role;
   joinedAt: string;


### PR DESCRIPTION
## 연관된 이슈

> ex) #112 

## 작업 내용

> mock api server 만들다보니 http request body 타입이 재사용되어서, 타입을 분리했습니다.

## 리뷰 요구사항(선택)

제안 사항 언제든 말씀해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 요청 및 응답 타입 정의를 체계적으로 정리하여 코드 일관성 및 유지보수성 향상
  * 인증, 크루, 세션, 사용자 프로필 관련 API의 타입 안정성 강화
  * 크루 멤버 조회 함수명 개선으로 API 명확성 증대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->