### PR TITLE
feature(#150): Public route 및 catch-all-segment route 핸들링 로직 수정

### DIFF
--- a/src/app/api/[...slug]/route.ts
+++ b/src/app/api/[...slug]/route.ts
@@ -1,36 +1,52 @@
+import { NextRequest } from 'next/server';
 import { handleRequest } from '@/api/util';
 
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  return handleRequest(request, params);
+  const { slug } = await params;
+  const pathname = slug.join('/');
+
+  return handleRequest(request, pathname);
 }
 
 export async function POST(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  return handleRequest(request, params);
+  const { slug } = await params;
+  const pathname = slug.join('/');
+
+  return handleRequest(request, pathname);
 }
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  return handleRequest(request, params);
+  const { slug } = await params;
+  const pathname = slug.join('/');
+
+  return handleRequest(request, pathname);
 }
 
 export async function DELETE(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  return handleRequest(request, params);
+  const { slug } = await params;
+  const pathname = slug.join('/');
+
+  return handleRequest(request, pathname);
 }
 
 export async function PATCH(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
-  return handleRequest(request, params);
+  const { slug } = await params;
+  const pathname = slug.join('/');
+
+  return handleRequest(request, pathname);
 }

--- a/src/app/api/crews/[crewId]/members/[userId]/role/route.ts
+++ b/src/app/api/crews/[crewId]/members/[userId]/role/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/api/crews/[crewId]/members/[userId]/role'>
+) {
+  const { crewId, userId } = await ctx.params;
+  return handleRequest(
+    request,
+    `/api/crews/${crewId}/members/${userId}/role`,
+    false
+  );
+}

--- a/src/app/api/crews/[crewId]/members/count/route.ts
+++ b/src/app/api/crews/[crewId]/members/count/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/api/crews/[crewId]/members/count'>
+) {
+  const { crewId } = await ctx.params;
+  return handleRequest(request, `/api/crews/${crewId}/members/count`, false);
+}

--- a/src/app/api/crews/[crewId]/members/route.ts
+++ b/src/app/api/crews/[crewId]/members/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/api/crews/[crewId]/members'>
+) {
+  const { crewId } = await ctx.params;
+  return handleRequest(request, `/api/crews/${crewId}/members`, false);
+}

--- a/src/app/api/crews/[crewId]/route.ts
+++ b/src/app/api/crews/[crewId]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/api/crews/[crewId]'>
+) {
+  const { crewId } = await ctx.params;
+  return handleRequest(request, `/api/crews/${crewId}`, false);
+}

--- a/src/app/api/crews/route.ts
+++ b/src/app/api/crews/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(request: NextRequest) {
+  return handleRequest(request, '/api/crews', false);
+}

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/api/sessions/[sessionId]'>
+) {
+  const { sessionId } = await ctx.params;
+  return handleRequest(request, `/api/sessions/${sessionId}`, false);
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from 'next/server';
+import { handleRequest } from '@/api/util';
+
+export async function GET(request: NextRequest) {
+  return handleRequest(request, '/api/sessions', false);
+}


### PR DESCRIPTION
## 연관된 이슈

this issue closes #150

## 작업 내용

> Public route 및 catch-all-segment route 핸들링 로직 수정

handleRequest 리팩토링으로 public route에 인증을 생략할 수 있도록 변경

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 크루 정보, 회원 목록, 회원 수 및 회원 역할 접근을 포함한 크루 데이터 관리를 위한 API 엔드포인트가 추가되었습니다.
  * 세션 관리 및 데이터 검색을 위한 API 엔드포인트가 추가되었습니다.

* **리팩토링**
  * 모든 엔드포인트에서 요청 처리를 간소화하기 위한 중앙 집중식 API 요청 처리 유틸리티가 구현되었습니다.
  * 일관성 및 유지보수성 향상을 위해 새로운 공유 요청 핸들러 패턴을 사용하도록 API 라우트가 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->