### PR TITLE
fix: POST requests를 보낼 때 duplex 옵션 명시적 포함

### DIFF
--- a/src/app/api/[...slug]/route.ts
+++ b/src/app/api/[...slug]/route.ts
@@ -7,7 +7,7 @@ const handler = async (
 ) => {
   const { slug } = await params;
   const pathname = slug.join('/');
-  console.log('pathname from slug:', pathname);
+
   return handleRequest(request, pathname, true);
 };
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,7 +59,10 @@ export async function handleRequest(
       ? pathname.slice(1)
       : pathname;
     const requestPath = proxyUrl(`/api/${trimmedPathname}?${searchParams}`);
-    console.log('requestPath: ', requestPath);
+
+    const hasBody =
+      request.method !== 'GET' && request.method !== 'HEAD' && request.body;
+
     const proxyResponse = await fetch(requestPath, {
       method: request.method,
       headers: {
@@ -68,11 +71,9 @@ export async function handleRequest(
         ...(requiresAuth &&
           accessToken && { Authorization: `Bearer ${accessToken}` }),
       },
-      body:
-        request.method !== 'GET' && request.method !== 'HEAD'
-          ? request.body
-          : undefined,
+      body: hasBody ? request.body : undefined,
       cache: requiresAuth ? 'no-cache' : 'default',
+      ...(hasBody && { duplex: 'half' }),
     });
 
     if (!proxyResponse.ok) {


### PR DESCRIPTION
## 연관된 이슈

closes #195 

## 작업 내용

fetch 요청의 두번째 인자 RequestInit 내에 POST requests를 보낼 때 duplex 옵션 명시적 포함하도록 수정했습니다.

2025-12-18 아침에 같이 확인한 대로 일단 지금 있는 문제는 당장 해결은 되는 것 같고 프로젝트 범위상 다른 요청은 없어서 괜찮을 것 같습니다.
http standard와 fetch 실 구현 차이로 추측이 되는데 이 부분은 시간 나면 조금 더 공부해봐야 할 것 같습니다.

[RequestInit: duplex option is required when sending a body · Issue #46221 · nodejs/node](https://github.com/nodejs/node/issues/46221)
[fetch RequestDuplex is "full" even set as "half" · nodejs/undici · Discussion #1760](https://github.com/nodejs/undici/discussions/1760)

[Request: duplex property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/duplex)
[Request: method property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/method)
[ReadableStream - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)

[The full-duplex aspect of HTTP you’ve never heard of – A-yon's Blog](https://ayon.li/the-full-duplex-aspect-of-http-youve-never-heard-of)

[stream - Fetch with ReadableStream as Request Body - Stack Overflow](https://stackoverflow.com/questions/40939857/fetch-with-readablestream-as-request-body)

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 불필요한 디버깅 코드 제거

* **개선 사항**
  * API 요청 처리 로직 최적화 및 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->