### PR TITLE
feature: useMediaQuery 훅 추가

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -11,10 +11,8 @@ export type Breakpoint = keyof typeof BREAKPOINTS;
 
 type BreakpointQuery =
   | { min: Exclude<Breakpoint, 'mobile'>; max?: never }
-  | {
-      min: Exclude<Breakpoint, 'mobile' | 'desktop'>;
-      max: Exclude<Breakpoint, 'mobile'>;
-    };
+  | { min: 'tablet'; max: 'laptop' | 'desktop' }
+  | { min: 'laptop'; max: 'desktop' };
 
 /**
  * 현재 뷰포트가 설정한 media query와 일치하는지 여부를 반환하는 훅입니다.


### PR DESCRIPTION
## 작업 내용

useMediaQuery 훅을 추가했습니다.
세션 상세 페이지 레이아웃에 필요해서 추가했습니다.

## 사용 예시

```tsx
'use client';

import { useMediaQuery } from '@/hooks/useMediaQuery';

export default function HomePage() {
  const isTabletUp = useMediaQuery({ min: 'tablet' });
  const isTabletOnly = useMediaQuery({ min: 'tablet', max: 'laptop' });

  return (
    <main className="h-main flex items-center justify-center">
      <div className={isTabletUp ? 'bg-red-500' : 'bg-blue-500'}>asdasdasdad</div>
    </main>
  );
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 반응형 디자인 유틸리티 추가
* 여러 화면 크기 기준점 지원 (모바일, 태블릿, 랩톱, 데스크톱)
* 미디어 쿼리 빌더 도입으로 동적 화면 크기 감지 기능 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->