### PR TITLE
fix: 뷰포트 변화시 조건 분기로 일어나는 리렌더링 이슈

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -26,6 +26,7 @@ import SafeImage from '@/components/ui/SafeImage';
 import UserAvatar from '@/components/ui/UserAvatar';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { formatDDay, formatKoYMD, formatKoYYMDMeridiemTime } from '@/lib/time';
+import { cn } from '@/lib/utils';
 import { Crew, Review } from '@/types';
 import { Session } from '@/types/session';
 
@@ -66,16 +67,18 @@ export default function Page() {
   const review = reviews?.content[0] || null;
 
   return (
-    <main
-      className="h-main laptop:bg-gray-900 relative bg-gray-800"
-      style={{ paddingBottom: `${height}px` }}
-    >
-      <SessionDetailView
-        session={session}
-        crew={crew}
-        review={review}
-        participants={participants}
-      />
+    <>
+      <main
+        className="h-main laptop:bg-gray-900 bg-gray-800"
+        style={{ paddingBottom: 96 }}
+      >
+        <SessionDetailView
+          session={session}
+          crew={crew}
+          review={review}
+          participants={participants}
+        />
+      </main>
       <FixedBottomBar ref={ref}>
         <div className="flex items-center gap-7">
           <div className="flex items-center gap-4">
@@ -87,7 +90,7 @@ export default function Page() {
           </Button>
         </div>
       </FixedBottomBar>
-    </main>
+    </>
   );
 }
 
@@ -104,9 +107,26 @@ function SessionDetailView({
 }) {
   const isLaptopUp = useMediaQuery({ min: 'laptop' });
 
-  if (isLaptopUp) {
-    return (
-      <div className="mx-auto flex max-w-[1120px] gap-10 bg-gray-900 py-10">
+  return (
+    <>
+      <div
+        className={cn(
+          'flex flex-col bg-gray-800 py-10',
+          isLaptopUp && 'hidden'
+        )}
+      >
+        <SessionImage image={session.image} name={session.name} />
+        <SessionShortInfo session={session} crewId={crew.id} />
+        <SessionDetailInfo session={session} participants={participants} />
+        <CrewShortInfo crew={crew} review={review} />
+      </div>
+
+      <div
+        className={cn(
+          'mx-auto flex max-w-[1120px] gap-10 bg-gray-900 py-10',
+          !isLaptopUp && 'hidden'
+        )}
+      >
         <div className="flex flex-1 flex-col gap-10 px-5">
           <SessionImage image={session.image} name={session.name} />
           <SessionDetailInfo session={session} participants={participants} />
@@ -116,16 +136,7 @@ function SessionDetailView({
           <CrewShortInfo crew={crew} review={review} />
         </div>
       </div>
-    );
-  }
-
-  return (
-    <div className="bg-gray-800 py-10">
-      <SessionImage image={session.image} name={session.name} />
-      <SessionShortInfo session={session} crewId={crew.id} />
-      <SessionDetailInfo session={session} participants={participants} />
-      <CrewShortInfo crew={crew} review={review} />
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 연관된 이슈

FixedBottomBar 수정 사항 반영은 좀 더 테스트 후에 이슈로 설명 더 자세하게 한 다음 PR 올리겠습니다.

그 부분 관련해서 테스트하다가 지금은 뷰포트 변화에 따라서 조건부로 렌더링됩니다.
이렇게 되면 브라우저 사이즈가 바뀔 때마다 컴포넌트들이 리렌더링 되면서 fetch 요청도 다시 보내게 됩니다.

isLaptopUp의 boolean 값에 따라 조건부로 해당하는 트리를 hidden 처리합니다.

## 작업 내용

## 리뷰 요구사항(선택)

두번째로 approve 하시는 분은 바로 머지 부탁드립니다. 🙇‍♂️🙇‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 세션 상세 페이지의 레이아웃을 반응형으로 개선했습니다.
  * 작은 화면에서는 콘텐츠가 수직으로 배열되고, 노트북 이상의 큰 화면에서는 좌우 배치로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->