### PR TITLE
feature: 로그인 되지 않은 상태에서 헤더의 로그인 클릭시 원래 있던 페이지로 리디랙션

### DIFF
--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Eye, EyeOff } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { Route } from 'next';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import Button from '@/components/ui/Button';
@@ -10,11 +11,14 @@ import { useSigninForm } from '@/hooks/auth/useSigninForm';
 
 export default function SigninForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const { form, submit, isPending } = useSigninForm({
     onSuccess: () => {
       toast.success('로그인 성공!');
-      router.push('/');
+      const redirect = searchParams.get('redirect') || '/';
+
+      router.push(decodeURIComponent(redirect) as Route<'/'>);
     },
     onError: (message) => {
       toast.error(`로그인 실패: ${message}`);

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -133,9 +133,14 @@ function UserMenu({ user }: { user: Profile }) {
 }
 
 function GuestMenu() {
+  const pathname = usePathname();
+
   return (
     <Link
-      href="/signin"
+      href={{
+        pathname: '/signin',
+        query: { redirect: pathname },
+      }}
       className="text-body3-semibold tablet:text-body2-semibold mx-2"
     >
       로그인


### PR DESCRIPTION
## 연관된 이슈

연관된 이슈 없음

## 작업 내용

로그인 성공시 redirect 쿼리가 있는 경우 '/' 대신 그 주소로 redirect
`http://localhost:3000/signin?redirect=%2Fcrews%2F2`

## 리뷰 요구사항(선택)

이 부분은 꼭 반영해야 된다는 아니고 크루 상세 페이지 구현하면서 MSW에서 새로고침을 했을 때, 로그인이 풀려서 원래 페이지로 돌아오면 좋을 것 같다는 생각에 구현해봤습니다. 꼭 필요한 기능인지 의견이 궁금합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- **로그인 후 이전 페이지로 복귀**: 로그인 버튼을 클릭할 때 현재 페이지 정보가 기억됩니다. 로그인 성공 후 항상 홈페이지로 이동하는 대신, 로그인하기 전에 방문하던 페이지로 자동 이동됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->