### PR TITLE
feat: requiresAuth가 false여도 토큰이 있으면 삽입

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -71,7 +71,7 @@ export async function handleRequest(
         ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
       },
       body: hasBody ? request.body : undefined,
-      cache: requiresAuth ? 'no-cache' : 'default',
+      cache: requiresAuth || accessToken ? 'no-cache' : 'default',
       ...(hasBody && { duplex: 'half' }),
     });
 


### PR DESCRIPTION
## 연관된 이슈

세션 찜 기능

## 작업 내용

세션 정보를 불러오는 건 public route지만,
세션 정보의 `like` 필드는 로그인 유무에 따라 다르게 동작합니다.

public route의 경우 인증 토큰이 있다면 인증 토큰을 담아서 보내도 문제가 없다고 판단해서 해당 기능을 추가했습니다.

## 기대 효과

이제 세션 정보를 불러올 때 
게스트: like는 항상 false
로그인한 사용자: like 여부에 따라 항상 t/f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 인증 토큰 초기화 및 갱신 흐름을 안정화하여 토큰 없을 때 자동으로 로그인 화면으로 리디렉션되도록 개선
  * 액세스 토큰이 존재하면 항상 인증 헤더를 포함하도록 처리해 요청 인증 일관성 향상
  * 토큰 갱신 실패 시 로깅과 함께 안전하게 로그인 화면으로 리디렉션되도록 오류 처리 강화
  * 인증 관련 캐시 제어를 강화하여 인증 필요 시 항상 최신 토큰 사용 보장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->