### PR TITLE
feat: 내가 만든 세션 관리 페이지 구현

### DIFF
--- a/src/app/my/manage/page.tsx
+++ b/src/app/my/manage/page.tsx
@@ -2,10 +2,8 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { userQueries } from '@/api/queries/userQueries';
 import SessionCard from '@/components/session/SessionCard';
-import Button from '@/components/ui/Button';
 import Spinner from '@/components/ui/Spinner';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -13,7 +11,6 @@ import { Session } from '@/types';
 
 export default function MyCreatedSessionsPage() {
   const isMobile = useMediaQuery({ max: 'tablet' });
-  const router = useRouter();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteQuery(userQueries.me.sessions.created());
@@ -21,7 +18,7 @@ export default function MyCreatedSessionsPage() {
   const sessions = data?.sessions ?? [];
   const hasNoSessions = !isLoading && sessions.length === 0;
 
-  const bottomRef = useInfiniteScroll(fetchNextPage, !!hasNextPage);
+  const bottomRef = useInfiniteScroll(fetchNextPage, hasNextPage);
 
   const normalizeSession = (
     session: Omit<Session, 'description'>


### PR DESCRIPTION
## 연관된 이슈

- #198 

## 작업 내용

마이페이지 내의 세션 관리 페이지를 구현했습니다

무한 스크롤로 구현했습니다

### 내가 만든 세션이 없을경우
<img width="2559" height="1384" alt="image" src="https://github.com/user-attachments/assets/638f62f6-539a-4b31-8d07-3ee796b1c17e" />

### 내가 만든 세션이 있는 경우 (PC)
<img width="2559" height="1393" alt="image" src="https://github.com/user-attachments/assets/e30fbafe-00dc-4810-855a-17fba1f8c5a0" />

### 내가 만든 세션이 있는 경우 (Tablet)
<img width="867" height="1151" alt="image" src="https://github.com/user-attachments/assets/ef7c4025-4af1-4db6-91bc-2bba3e93cb2a" />

### 내가 만든 세션이 있는 경우 (Mobile)
<img width="587" height="1273" alt="image" src="https://github.com/user-attachments/assets/082babd4-2176-44a1-ae7b-62f17c437d92" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 세션 관리 페이지에 클라이언트사이드 무한 스크롤 페이지네이션 도입
  * 불러오는 중 표시 및 다음 페이지 로딩 인디케이터 추가
  * 세션이 없을 때 안내 이미지와 메시지로 구성된 빈 상태 화면 추가
  * 세션을 카드형 그리드로 정렬해 목록 가독성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->