### PR TITLE
feat: 마이페이지의 내 세션에서 예정된 세션, 완료된 세션이 없을 경우 디자인 추가

### DIFF
--- a/src/app/my/sessions/page.tsx
+++ b/src/app/my/sessions/page.tsx
@@ -71,7 +71,10 @@ export default function Page() {
   const completedCount = completedSessions?.sessions.length ?? 0;
 
   const isLoading = isLoadingScheduled || isLoadingCompleted;
-  const hasNoSessions = scheduledCount === 0 && completedCount === 0;
+
+  const hasNoScheduled = scheduledCount === 0;
+  const hasNoCompleted = completedCount === 0;
+  const hasNoSessions = hasNoScheduled && hasNoCompleted;
 
   if (isLoading) {
     return (
@@ -87,7 +90,7 @@ export default function Page() {
         <Image
           width={isMobile ? 240 : 300}
           height={isMobile ? 218 : 272}
-          src={'/assets/empty-session.png'}
+          src={'/assets/session-default.png'}
           alt="세션 없음"
         />
         <p className="tablet:text-body2-medium text-body3-regular text-center text-gray-300">
@@ -113,71 +116,99 @@ export default function Page() {
       <div>
         <h2 className="text-body1-semibold mb-5 text-gray-50">예정된 세션</h2>
 
-        <div
-          ref={scheduledRef}
-          className="tablet:gap-4 flex gap-3 overflow-x-auto [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-500 [&::-webkit-scrollbar-track]:bg-transparent"
-        >
-          {scheduledSessions?.sessions.map((session) => (
-            <div
-              key={session.id}
-              className="laptop:w-[calc((100%-32px)/3)] tablet:w-[calc((100%-16px)/2)] w-[calc((100%-12px)/2)] shrink-0"
+        {hasNoScheduled ? (
+          <div className="flex flex-col items-center gap-6">
+            <Image
+              width={isMobile ? 150 : 200}
+              height={isMobile ? 136 : 181}
+              src="/assets/session-default.png"
+              alt="예정된 세션 없음"
+            />
+            <p className="tablet:text-body2-medium text-body3-regular text-center text-gray-300">
+              아직 예정된 세션이 없어요
+              <br />
+              다양한 세션을 구경하러 가볼까요?
+            </p>
+            <Button
+              size={isMobile ? 'sm' : 'default'}
+              onClick={() => router.push('/sessions')}
             >
-              <SessionCard session={normalizeSession(session)} />
-            </div>
-          ))}
-          {isFetchingNextScheduled && (
-            <div className="flex shrink-0 items-center px-4">
-              <Spinner className="text-brand-500 size-5" />
-            </div>
-          )}
-        </div>
+              세션 구경하러 가기
+            </Button>
+          </div>
+        ) : (
+          <div
+            ref={scheduledRef}
+            className="tablet:gap-4 flex gap-3 overflow-x-auto [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-500 [&::-webkit-scrollbar-track]:bg-transparent"
+          >
+            {scheduledSessions?.sessions.map((session) => (
+              <div
+                key={session.id}
+                className="laptop:w-[calc((100%-32px)/3)] tablet:w-[calc((100%-16px)/2)] w-[calc((100%-12px)/2)] shrink-0"
+              >
+                <SessionCard session={normalizeSession(session)} />
+              </div>
+            ))}
+            {isFetchingNextScheduled && (
+              <div className="flex shrink-0 items-center px-4">
+                <Spinner className="text-brand-500 size-5" />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div>
         <h2 className="text-body1-semibold mb-5 text-gray-50">완료된 세션</h2>
 
-        <div className="tablet:gap-3 flex flex-col gap-2">
-          {completedSessions?.sessions.map((session) => {
-            const isHost = userInfo
-              ? session.hostUserId === userInfo.id
-              : false;
-            const showReviewButton = !session.reviewed && userInfo && !isHost;
+        {hasNoCompleted ? (
+          <div className="text-body2-medium py-20 text-center text-gray-300">
+            아직 완료된 세션이 없어요!
+          </div>
+        ) : (
+          <div className="tablet:gap-3 flex flex-col gap-2">
+            {completedSessions?.sessions.map((session) => {
+              const isHost = userInfo
+                ? session.hostUserId === userInfo.id
+                : false;
+              const showReviewButton = !session.reviewed && userInfo && !isHost;
 
-            return (
-              <div key={session.id} className="flex flex-col gap-3">
-                <CompletedSessionCard
-                  session={normalizeSession(session)}
-                  size={isMobile ? 'sm' : 'lg'}
-                  showRanks={false}
-                  showBadges={!isMobile}
-                  action={
-                    showReviewButton ? (
-                      <Button
-                        variant={'outlined'}
-                        size={isMobile ? 'sm' : 'default'}
-                        className="tablet:px-6 px-3"
-                        onClick={() => {
-                          handleOpenReview(session);
-                        }}
-                      >
-                        리뷰 작성하기
-                      </Button>
-                    ) : null
-                  }
-                  actionPlacement={isMobile ? 'bottom' : 'side'}
-                />
-                <hr className="border-gray-750 w-full" />
+              return (
+                <div key={session.id} className="flex flex-col gap-3">
+                  <CompletedSessionCard
+                    session={normalizeSession(session)}
+                    size={isMobile ? 'sm' : 'lg'}
+                    showRanks={false}
+                    showBadges={!isMobile}
+                    action={
+                      showReviewButton ? (
+                        <Button
+                          variant={'outlined'}
+                          size={isMobile ? 'sm' : 'default'}
+                          className="tablet:px-6 px-3"
+                          onClick={() => {
+                            handleOpenReview(session);
+                          }}
+                        >
+                          리뷰 작성하기
+                        </Button>
+                      ) : null
+                    }
+                    actionPlacement={isMobile ? 'bottom' : 'side'}
+                  />
+                  <hr className="border-gray-750 w-full" />
+                </div>
+              );
+            })}
+            <div ref={completedRef} className="h-5" />
+
+            {isFetchingNextCompleted && (
+              <div className="flex shrink-0 items-center justify-center">
+                <Spinner className="text-brand-500 size-5" />
               </div>
-            );
-          })}
-          <div ref={completedRef} className="h-5" />
-
-          {isFetchingNextCompleted && (
-            <div className="flex shrink-0 items-center justify-center">
-              <Spinner className="text-brand-500 size-5" />
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </div>
       <ReviewModal open={open} setOpen={setOpen} session={selectedSession} />
     </section>


### PR DESCRIPTION
## 연관된 이슈

- #198 

## 작업 내용

마이페이지의 내 세션 페이지에서 예정된 세션 섹션과 완료된 세션 섹션이 분리되어 있습니다.

두 섹션이 모두 비어있을 경우에 대한 처리는 했는데

각 섹션 중 하나만 비어있는 경우에 대한 처리를 안해둬서, 진행했습니다

### 예정된 세션이 없을 경우
기존|변경 후
--|--
<img width="1227" height="1248" alt="image" src="https://github.com/user-attachments/assets/39447bc0-8511-45ae-bea7-5765ae5d8059" />|<img width="1249" height="1259" alt="image" src="https://github.com/user-attachments/assets/f0287aac-848d-4a36-9577-15c2290102eb" />

### 완료된 세션이 없을 경우

<img width="1222" height="1107" alt="image" src="https://github.com/user-attachments/assets/40b9233c-da7a-4c10-94b7-c2bb03062b3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예정된 세션이 없을 때 개선된 빈 상태 UI(이미지, 메시지, 이동 버튼)를 표시합니다.
  * 완료된 세션이 없을 때 중앙 정렬된 메시지를 표시합니다.
  * 모바일과 데스크톱에서 최적화된 반응형 레이아웃.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->