### PR TITLE
fix: Vercel 이미지 최적화 한도 초과 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    minimumCacheTTL: 2678400,
     remotePatterns: [
       // mock 이미지 도메인
       {


### PR DESCRIPTION
## 연관된 이슈

없음

## 작업 내용

Vercel 이미지 최적화 한도 초과 관련해서 다음과 같은 현상 발생하여 (스크린샷 참고)
images 설정에 `minimumCacheTTL` 추가해 해결하였습니다.

해결 여부는 Vercel 배포 후 확인해야 할 것 같습니다.

### 스크린샷 
<img width="1552" height="1654" alt="image" src="https://github.com/user-attachments/assets/e64b4866-ff9f-4866-8cdc-3fe879446f2d" />

## 참고

- [Vercel 이미지 최적화 한도 초과 관련 이슈와 해결 과정](https://www.misung.dev/blog/vercel-image-optimization-limit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 이미지 캐싱 설정을 업데이트하여 원격 이미지의 캐시 보관 시간을 연장했습니다. 이를 통해 원격 이미지 로딩 성능이 개선됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->