### PR TITLE
refactor(fetch): src/api/fetch의 API 요청 함수 개선

### DIFF
--- a/src/api/fetch/auth.ts
+++ b/src/api/fetch/auth.ts
@@ -5,10 +5,7 @@ export type SignupRequestBody = UserCredentials & { name: string };
 export async function postSignup(body: SignupRequestBody) {
   return request<User>('/api/auth/signup', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 
@@ -16,10 +13,7 @@ export type SigninResponseData = { token: string };
 export async function postSignin(body: UserCredentials) {
   return request<SigninResponseData>('/api/auth/signin', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 

--- a/src/api/fetch/crews.ts
+++ b/src/api/fetch/crews.ts
@@ -41,10 +41,8 @@ export async function joinCrew(crewId: number) {
 
 export type GetCrewsResponse = SliceData<Crew>;
 export async function getCrews(queryParams?: CrewListFilters) {
-  const searchParams = buildQueryParams<CrewListFilters>(queryParams);
-  const queryString = searchParams.toString();
-
-  return request<GetCrewsResponse>(`/api/crews?${queryString}`);
+  const query = buildQueryParams(queryParams);
+  return request<GetCrewsResponse>(`/api/crews?${query}`);
 }
 
 export type GetCrewDetailResponse = Crew;
@@ -57,9 +55,7 @@ export async function getCrewMembers(
   crewId: number,
   queryParams?: MemberRoleFilters
 ) {
-  const query = new URLSearchParams(
-    queryParams as Record<string, string>
-  ).toString();
+  const query = buildQueryParams(queryParams);
   return request<GetCrewMembersResponse>(
     `/api/crews/${crewId}/members?${query}`
   );
@@ -183,9 +179,7 @@ export async function getCrewReviews(
   crewId: number,
   queryParams?: PaginationQueryParams
 ) {
-  const query = new URLSearchParams(
-    queryParams as Record<string, string>
-  ).toString();
+  const query = buildQueryParams(queryParams);
 
   return request<GetCrewReviewsResponse>(
     `/api/crews/${crewId}/reviews?${query}`

--- a/src/api/fetch/crews.ts
+++ b/src/api/fetch/crews.ts
@@ -21,8 +21,7 @@ export type CrewRequestBody = Pick<
 export async function createCrew(body: CrewRequestBody) {
   return request<Crew>('/api/crews', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body,
   });
 }
 
@@ -35,7 +34,6 @@ type JoinCrewResponse = {
 export async function joinCrew(crewId: number) {
   return request<JoinCrewResponse>(`/api/crews/${crewId}/join`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
   });
 }
 
@@ -94,8 +92,7 @@ export async function delegateCrewLeader(
 ) {
   return request<DelegateCrewLeaderResponse>(`/api/crews/${crewId}/leader`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body,
   });
 }
 
@@ -126,8 +123,7 @@ export async function updateMemberRole(
     `/api/crews/${crewId}/members/${userId}/role`,
     {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body,
     }
   );
 }
@@ -161,8 +157,7 @@ export async function updateCrewDetail(
 ) {
   return request<UpdateCrewDetailResponse>(`/api/crews/${crewId}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body,
   });
 }
 
@@ -180,7 +175,6 @@ export async function getCrewReviews(
   queryParams?: PaginationQueryParams
 ) {
   const query = buildQueryParams(queryParams);
-
   return request<GetCrewReviewsResponse>(
     `/api/crews/${crewId}/reviews?${query}`
   );

--- a/src/api/fetch/image.ts
+++ b/src/api/fetch/image.ts
@@ -12,10 +12,7 @@ export type GetPresignedUrlResponse = {
 export async function getPresignedUrl(body: GetPresignedUrlRequest) {
   return request<GetPresignedUrlResponse>(`/api/images/presigned-url`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 

--- a/src/api/fetch/request.ts
+++ b/src/api/fetch/request.ts
@@ -27,9 +27,13 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return resData.data;
 }
 
+interface RequestOptions extends Omit<RequestInit, 'body'> {
+  body?: BodyInit | Record<string, unknown> | null;
+}
+
 export default async function request<T>(
   url: string | URL,
-  options?: RequestInit
+  options?: RequestOptions
 ): Promise<T> {
   // 서버 환경에서만 상대 경로를 절대 경로로 변환
   let absoluteUrl = url;
@@ -42,6 +46,22 @@ export default async function request<T>(
     absoluteUrl = new URL(url, baseUrl).toString();
   }
 
-  const response = await fetch(absoluteUrl, options);
+  const { body, headers, ...rest } = options ?? {};
+
+  const isJsonBody =
+    typeof body === 'object' &&
+    body !== null &&
+    !(body instanceof FormData) &&
+    !(body instanceof Blob) &&
+    !(body instanceof URLSearchParams);
+
+  const response = await fetch(absoluteUrl, {
+    ...rest,
+    headers: isJsonBody
+      ? { 'Content-Type': 'application/json', ...headers }
+      : headers,
+    body: isJsonBody ? JSON.stringify(body) : (body as BodyInit),
+  });
+
   return handleResponse<T>(response);
 }

--- a/src/api/fetch/request.ts
+++ b/src/api/fetch/request.ts
@@ -49,11 +49,10 @@ export default async function request<T>(
   const { body, headers, ...rest } = options ?? {};
 
   const isJsonBody =
-    typeof body === 'object' &&
     body !== null &&
-    !(body instanceof FormData) &&
-    !(body instanceof Blob) &&
-    !(body instanceof URLSearchParams);
+    typeof body === 'object' &&
+    (Object.getPrototypeOf(body) === Object.prototype ||
+      Object.getPrototypeOf(body) === null);
 
   const mergedHeaders = new Headers(headers);
   if (isJsonBody && !mergedHeaders.has('Content-Type')) {

--- a/src/api/fetch/request.ts
+++ b/src/api/fetch/request.ts
@@ -55,11 +55,14 @@ export default async function request<T>(
     !(body instanceof Blob) &&
     !(body instanceof URLSearchParams);
 
+  const mergedHeaders = new Headers(headers);
+  if (isJsonBody && !mergedHeaders.has('Content-Type')) {
+    mergedHeaders.set('Content-Type', 'application/json');
+  }
+
   const response = await fetch(absoluteUrl, {
     ...rest,
-    headers: isJsonBody
-      ? { 'Content-Type': 'application/json', ...headers }
-      : headers,
+    headers: mergedHeaders,
     body: isJsonBody ? JSON.stringify(body) : (body as BodyInit),
   });
 

--- a/src/api/fetch/reviews.ts
+++ b/src/api/fetch/reviews.ts
@@ -1,3 +1,4 @@
+import { buildQueryParams } from '@/lib/utils';
 import { PageData, PaginationQueryParams, Review } from '@/types';
 import request from './request';
 
@@ -7,16 +8,7 @@ export async function getSessionReviews(
   sessionId: number,
   queryParams?: PaginationQueryParams
 ) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetSessionReviewsResponse>(
     `/api/sessions/${sessionId}/reviews?${query}`
   );

--- a/src/api/fetch/reviews.ts
+++ b/src/api/fetch/reviews.ts
@@ -32,10 +32,7 @@ export async function createSessionReview(
     `/api/sessions/${sessionId}/reviews`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
+      body,
     }
   );
 }

--- a/src/api/fetch/sessions.ts
+++ b/src/api/fetch/sessions.ts
@@ -1,3 +1,4 @@
+import { buildQueryParams } from '@/lib/utils';
 import {
   CrewMember,
   MemberRoleFilters,
@@ -9,22 +10,7 @@ import request from './request';
 
 type GetSessionsResponse = SliceData<Session>;
 export async function getSessions(queryParams?: SessionListFilters) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-
-      if (Array.isArray(value)) {
-        value.forEach((item) => searchParams.append(key, item));
-      } else {
-        searchParams.append(key, String(value));
-      }
-    });
-  }
-
-  const query = searchParams.toString();
-
+  const query = buildQueryParams(queryParams);
   return request<GetSessionsResponse>(`/api/sessions?${query}`);
 }
 
@@ -95,10 +81,7 @@ export async function getSessionParticipants(
   sessionId: number,
   queryParams?: MemberRoleFilters
 ) {
-  const query = new URLSearchParams(
-    queryParams as Record<string, string>
-  ).toString();
-
+  const query = buildQueryParams(queryParams);
   return request<GetSessionParticipantsResponse>(
     `/api/sessions/${sessionId}/participants?${query}`
   );

--- a/src/api/fetch/sessions.ts
+++ b/src/api/fetch/sessions.ts
@@ -34,10 +34,7 @@ export type CreateSessionResponse = Omit<Session, 'liked'>;
 export async function createSession(body: CreateSessionRequestBody) {
   return request<CreateSessionResponse>('/api/sessions', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 
@@ -98,10 +95,7 @@ export async function updateSessionDetail(
 ) {
   return request<UpdateSessionDetailResponse>(`/api/sessions/${sessionId}`, {
     method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 

--- a/src/api/fetch/user.ts
+++ b/src/api/fetch/user.ts
@@ -21,10 +21,7 @@ export type UpdateMyProfileRequestBody = Partial<
 export async function updateMyProfile(body: UpdateMyProfileRequestBody) {
   return request<Profile>('/api/user', {
     method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+    body,
   });
 }
 

--- a/src/api/fetch/user.ts
+++ b/src/api/fetch/user.ts
@@ -1,3 +1,4 @@
+import { buildQueryParams } from '@/lib/utils';
 import {
   Crew,
   PageData,
@@ -34,48 +35,21 @@ export async function getUserProfile(userId: number) {
 
 export type GetMyReviewsResponse = PageData<Review>;
 export async function getMyReviews(queryParams?: PaginationQueryParams) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyReviewsResponse>(`/api/user/me/reviews?${query}`);
 }
 
 // 내가 찜한 세션 목록 조회
 export type GetMyLikedSessionsResponse = SliceData<Session>;
 export async function getMyLikedSessions(queryParams?: PaginationQueryParams) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyLikedSessionsResponse>(`/api/user/me/likes?${query}`);
 }
 
 // 내가 만든 크루 목록 조회 (무한스크롤)
 export type GetMyOwnedCrewsResponse = SliceData<Crew>;
 export async function getMyOwnedCrews(queryParams?: PaginationQueryParams) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyOwnedCrewsResponse>(`/api/user/me/crews/owned?${query}`);
 }
 
@@ -85,16 +59,7 @@ export type GetMyJoinedCrewsItem = Crew & {
 };
 export type GetMyJoinedCrewsResponse = SliceData<GetMyJoinedCrewsItem>;
 export async function getMyJoinedCrews(queryParams?: PaginationQueryParams) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyJoinedCrewsResponse>(`/api/user/me/crews?${query}`);
 }
 
@@ -105,16 +70,7 @@ export type GetMyCreatedSessionsResponse = SliceData<
 export async function getMyCreatedSessions(
   queryParams?: PaginationQueryParams
 ) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyCreatedSessionsResponse>(
     `/api/user/me/sessions?${query}`
   );
@@ -135,16 +91,7 @@ export type GetMyParticipatingSessionsResponse =
 export async function getMyParticipatingSessions(
   queryParams?: GetMyParticipatingSessionsQuery
 ) {
-  const searchParams = new URLSearchParams();
-
-  if (queryParams) {
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      searchParams.append(key, String(value));
-    });
-  }
-
-  const query = searchParams.toString();
+  const query = buildQueryParams(queryParams);
   return request<GetMyParticipatingSessionsResponse>(
     `/api/user/me/sessions/participating?${query}`
   );


### PR DESCRIPTION
## 작업 내용

`src/api/fetch`의 API 요청 함수 유지보수성 개선

1. searchParams 빌더 함수 적용
problem: 객체를 `URLSearchParams`로 변환하는 작업이 반복되지만 각 함수 내부에서 직접 처리하는 경우가 있었습니다.
solution: 같은 작업을 하나의 인터페이스로 관리해 유지보수성을 개선했습니다.

2. 반복된 headers, body 설정 작업 제거
problem:     
API 요청 함수마다 `request` 함수에 아래 option 인자를 전달하는 코드가 반복되었습니다.
```js
{ 
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify(body),
}
```
solution: 대부분의 request body가 직렬화된 json 형식인 걸 감안해, 이 코드를 `request` 함수에서 처리했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * API 요청 처리와 쿼리 파라미터 생성 방식을 통합해 페이로드 처리와 쿼리 인코딩의 일관성을 높였습니다.
  * 요청 헤더·페이로드 직렬화 관련 중복을 정리해 네트워크 동작 안정성과 유지보수성을 개선했습니다. 사용자 인터페이스나 기능 변화는 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->